### PR TITLE
Don't move Context, Actix-web specialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "microtemplate"
 description = "Fast, microscopic helper crate for runtime string interpolation."
 repository = "https://github.com/Legend-of-iPhoenix/microtemplate"
-version = "1.0.4"
+version = "1.0.4+frk.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["template"]
@@ -10,6 +10,8 @@ categories = ["template-engine"]
 readme = "README.md"
 
 authors = ["_iPhoenix_ <theiphoenixconspiracy@gmail.com>"]
+
+publish = ["elleci"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "microtemplate"
 description = "Fast, microscopic helper crate for runtime string interpolation."
 repository = "https://github.com/Legend-of-iPhoenix/microtemplate"
-version = "1.0.3"
-edition = "2018"
+version = "1.0.4"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["template"]
 categories = ["template-engine"]
@@ -15,6 +15,10 @@ authors = ["_iPhoenix_ <theiphoenixconspiracy@gmail.com>"]
 
 [dependencies]
 microtemplate_derive = { path = "./microtemplate_derive", version = "1.0.0" }
+actix-web = { version = "4", optional = true }
+
+[features]
+actix-web = ["dep:actix-web"]
 
 [workspace]
 members = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,20 @@
 pub use microtemplate_derive::Substitutions;
 
+#[cfg(feature = "actix-web")]
+use actix_web::{dev::Path, dev::Url};
+
 pub trait Context {
     fn get_field(&self, field_name: &str) -> &str;
 }
 
-pub fn render<C: Context>(input: &str, context: C) -> String {
+#[cfg(feature = "actix-web")]
+impl Context for Path<Url> {
+    fn get_field(&self, field_name: &str) -> &str {
+        self.get(field_name).unwrap()
+    }
+}
+
+pub fn render<C: Context>(input: &str, context: &C) -> String {
     let mut output = String::with_capacity(input.len());
 
     let input_bytes = input.as_bytes();


### PR DESCRIPTION
- Prevent moving `Context` by using a reference;
- Implemented specialization for actix-web `Path<Url>` via `actix-web` feature;